### PR TITLE
Add admin text editor and publishing settings

### DIFF
--- a/backend/data-source.ts
+++ b/backend/data-source.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { DataSource } from "typeorm";
 import { User } from "./entities/user.js";
 import { Makale } from "./entities/Makale.js";
+import { Setting } from "./entities/Setting.js";
 
 
 
@@ -15,5 +16,5 @@ export const AppDataSource = new DataSource({
     database: process.env.DB_DATABASE,
     synchronize: true,
     logging: false,
-    entities: [User, Makale],
+    entities: [User, Makale, Setting],
 });

--- a/backend/entities/Setting.ts
+++ b/backend/entities/Setting.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class Setting {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ default: true })
+    allowAppPublishing: boolean;
+}

--- a/backend/router/makaleRouter.ts
+++ b/backend/router/makaleRouter.ts
@@ -3,17 +3,24 @@ import { AppDataSource } from '../data-source.js';
 import { Makale, MakaleStatus } from '../entities/Makale.js';
 import { User, UserRole } from '../entities/user.js';
 import { protect } from '../middleware/authMiddleware.js';
+import { Setting } from '../entities/Setting.js';
 
 export const router = Router();
 const makaleRepository = AppDataSource.getRepository(Makale);
 const userRepository = AppDataSource.getRepository(User);
+const settingRepository = AppDataSource.getRepository(Setting);
 
 // --- YENİ MAKALE OLUŞTURMA ---
 // Sadece giriş yapmış kullanıcılar (yazarlar veya adminler) yeni makale oluşturabilir.
 // Oluşturulan her yeni makalenin statüsü varsayılan olarak "pending" (onay bekliyor) olur.
 router.post('/', protect, async (req, res) => {
-		const { title, content } = req.body;
-		const userId = (req as any).user?.id;
+                const { title, content } = req.body;
+                const userId = (req as any).user?.id;
+
+                const setting = await settingRepository.findOne({ where: { id: 1 } });
+                if (setting && !setting.allowAppPublishing) {
+                        return res.status(403).json({ message: 'Makale yayınlama şu anda devre dışı.' });
+                }
 
 		if (!title || !content) {
 			return res.status(400).json({ message: 'Başlık ve içerik alanları zorunludur.' });

--- a/backend/router/settingsRouter.ts
+++ b/backend/router/settingsRouter.ts
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import { AppDataSource } from '../data-source.js';
+import { Setting } from '../entities/Setting.js';
+import { protect, authorize } from '../middleware/authMiddleware.js';
+import { UserRole } from '../entities/user.js';
+
+export const router = Router();
+const settingRepo = AppDataSource.getRepository(Setting);
+
+router.get('/', protect, authorize(UserRole.ADMIN, UserRole.SUPERADMIN), async (req, res) => {
+        try {
+                let setting = await settingRepo.findOne({ where: { id: 1 } });
+                if (!setting) {
+                        setting = settingRepo.create({ id: 1 });
+                        await settingRepo.save(setting);
+                }
+                res.json(setting);
+        } catch (error) {
+                res.status(500).json({ message: 'Ayarlar yüklenirken bir hata oluştu.', error });
+        }
+});
+
+router.put('/', protect, authorize(UserRole.ADMIN, UserRole.SUPERADMIN), async (req, res) => {
+        try {
+                const { allowAppPublishing } = req.body;
+                let setting = await settingRepo.findOne({ where: { id: 1 } });
+                if (!setting) {
+                        setting = settingRepo.create({ id: 1 });
+                }
+                if (typeof allowAppPublishing === 'boolean') {
+                        setting.allowAppPublishing = allowAppPublishing;
+                }
+                await settingRepo.save(setting);
+                res.json(setting);
+        } catch (error) {
+                res.status(500).json({ message: 'Ayarlar güncellenirken bir hata oluştu.', error });
+        }
+});
+
+export default router;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -4,6 +4,7 @@ import { AppDataSource } from './data-source.js';
 import { router as authRouter } from './router/authRoute.js';
 import { router as yazarRouter } from './router/yazarRouter.js';
 import { router as makaleRouter } from './router/makaleRouter.js';
+import { router as settingsRouter } from './router/settingsRouter.js';
 
 AppDataSource.initialize()
     .then(() => {
@@ -15,6 +16,7 @@ AppDataSource.initialize()
         app.use('/api/auth', authRouter);
         app.use('/api/yazarlar', yazarRouter);
         app.use('/api/makaleler', makaleRouter);
+        app.use('/api/settings', settingsRouter);
 
         const port = process.env.PORT || 5000;
         app.listen(port, () => {

--- a/frontend/src/admin/AdminLayout.jsx
+++ b/frontend/src/admin/AdminLayout.jsx
@@ -4,6 +4,7 @@ import { Box, Drawer, List, ListItem, ListItemButton, ListItemIcon, ListItemText
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ArticleIcon from '@mui/icons-material/Article';
 import PeopleIcon from '@mui/icons-material/People';
+import SettingsIcon from '@mui/icons-material/Settings';
 
 const drawerWidth = 260;
 
@@ -12,6 +13,7 @@ function AdminLayout() {
     { text: 'Anasayfa', icon: <DashboardIcon />, path: '/girne' },
     { text: 'Makale Yönetimi', icon: <ArticleIcon />, path: '/girne/makaleler' },
     { text: 'Yazar Yönetimi', icon: <PeopleIcon />, path: '/girne/yazarlar' },
+    { text: 'Ayarlar', icon: <SettingsIcon />, path: '/girne/ayarlar' },
   ];
 
   return (

--- a/frontend/src/admin/components/TextEditor.jsx
+++ b/frontend/src/admin/components/TextEditor.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactQuill from 'react-quill';
+import 'react-quill/dist/quill.snow.css';
+
+const TextEditor = ({ value, onChange }) => {
+        const modules = {
+                toolbar: [
+                        [{ header: [1, 2, 3, false] }],
+                        ['bold', 'italic', 'underline', 'strike'],
+                        [{ list: 'ordered' }, { list: 'bullet' }],
+                        ['link', 'image'],
+                        ['clean'],
+                ],
+        };
+
+        return (
+                <ReactQuill theme="snow" value={value} onChange={onChange} modules={modules} />
+        );
+};
+
+export default TextEditor;

--- a/frontend/src/admin/pages/Ayarlar.jsx
+++ b/frontend/src/admin/pages/Ayarlar.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { Paper, Typography, FormControlLabel, Switch, Alert } from '@mui/material';
+import axios from 'axios';
+
+const Ayarlar = () => {
+        const [allowAppPublishing, setAllowAppPublishing] = useState(true);
+        const [message, setMessage] = useState('');
+
+        useEffect(() => {
+                const fetchSettings = async () => {
+                        const token = localStorage.getItem('token');
+                        try {
+                                const res = await axios.get('/api/settings', {
+                                        headers: { Authorization: `Bearer ${token}` },
+                                });
+                                setAllowAppPublishing(res.data.allowAppPublishing);
+                        } catch (err) {
+                                setMessage('Ayarlar yüklenemedi.');
+                                console.error(err);
+                        }
+                };
+                fetchSettings();
+        }, []);
+
+        const handleToggle = async (e) => {
+                const value = e.target.checked;
+                setAllowAppPublishing(value);
+                const token = localStorage.getItem('token');
+                try {
+                        await axios.put(
+                                '/api/settings',
+                                { allowAppPublishing: value },
+                                { headers: { Authorization: `Bearer ${token}` } },
+                        );
+                        setMessage('Ayar güncellendi.');
+                } catch (err) {
+                        setMessage('Ayar güncellenemedi.');
+                        console.error(err);
+                }
+        };
+
+        return (
+                <Paper sx={{ p: 3 }}>
+                        <Typography variant="h5" gutterBottom>
+                                Ayarlar
+                        </Typography>
+                        {message && (
+                                <Alert severity={message.includes('güncellendi') ? 'success' : 'error'} sx={{ mb: 2 }}>
+                                        {message}
+                                </Alert>
+                        )}
+                        <FormControlLabel
+                                control={<Switch checked={allowAppPublishing} onChange={handleToggle} />}
+                                label="Uygulamadan yayınlamaya izin ver"
+                        />
+                </Paper>
+        );
+};
+
+export default Ayarlar;

--- a/frontend/src/admin/pages/MakaleYonetimi.jsx
+++ b/frontend/src/admin/pages/MakaleYonetimi.jsx
@@ -1,19 +1,20 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import {
-	Box,
-	TextField,
-	Button,
-	Typography,
-	Paper,
-	List,
-	ListItem,
-	ListItemText,
-	ListItemSecondaryAction,
-	IconButton,
-	CircularProgress,
-	Alert,
-	Divider,
+        Box,
+        TextField,
+        Button,
+        Typography,
+        Paper,
+        List,
+        ListItem,
+        ListItemText,
+        ListItemSecondaryAction,
+        IconButton,
+        CircularProgress,
+        Alert,
+        Divider,
 } from '@mui/material';
+import TextEditor from '../components/TextEditor.jsx';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import axios from 'axios';
@@ -173,16 +174,9 @@ const MakaleYonetimi = () => {
 						onChange={(e) => setTitle(e.target.value)}
 						margin="normal"
 					/>
-					<TextField
-						label="Makale İçeriği"
-						fullWidth
-						required
-						multiline
-						rows={10}
-						value={content}
-						onChange={(e) => setContent(e.target.value)}
-						margin="normal"
-					/>
+                                        <Box sx={{ mt: 2 }}>
+                                                <TextEditor value={content} onChange={setContent} />
+                                        </Box>
 					<Button type="submit" variant="contained" color="primary" sx={{ mt: 2 }}>
 						Makaleyi Onaya Gönder
 					</Button>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -19,6 +19,7 @@ import AdminDashboard from './admin/pages/AdminDashboard.jsx';
 import LoginPage from './admin/pages/LoginPage.jsx';
 import MakaleYonetimi from './admin/pages/MakaleYonetimi.jsx';
 import YazarYonetimi from './admin/pages/YazarYonetimi.jsx';
+import Ayarlar from './admin/pages/Ayarlar.jsx';
 
 const router = createBrowserRouter([
   {
@@ -39,6 +40,7 @@ const router = createBrowserRouter([
       { index: true, element: <AdminDashboard /> },
       { path: "makaleler", element: <MakaleYonetimi /> },
       { path: "yazarlar", element: <YazarYonetimi /> },
+      { path: "ayarlar", element: <Ayarlar /> },
     ]
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-awesome-reveal": "^4.3.1",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.62.0",
+        "react-quill": "^2.0.0",
         "react-router-dom": "^6.23.1",
         "react-scroll": "^1.9.3",
         "react-slick": "^0.30.3",
@@ -1826,6 +1827,15 @@
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
+    "node_modules/@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "license": "MIT",
+      "dependencies": {
+        "parchment": "^1.1.2"
+      }
+    },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
@@ -2291,7 +2301,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -2386,6 +2395,15 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -2601,6 +2619,26 @@
         }
       }
     },
+    "node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2612,7 +2650,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -2630,7 +2667,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -3250,6 +3286,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
+      "license": "MIT"
+    },
     "node_modules/express": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
@@ -3292,12 +3334,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "license": "Apache-2.0"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3544,7 +3598,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3737,7 +3790,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -3931,6 +3983,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -4058,7 +4126,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4198,7 +4265,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4583,6 +4649,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -4849,11 +4921,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5022,6 +5109,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -5252,6 +5345,34 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -5368,6 +5489,21 @@
       "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
       "license": "MIT"
     },
+    "node_modules/react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -5483,7 +5619,6 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -5787,7 +5922,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -5805,7 +5939,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-awesome-reveal": "^4.3.1",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.62.0",
+    "react-quill": "^2.0.0",
     "react-router-dom": "^6.23.1",
     "react-scroll": "^1.9.3",
     "react-slick": "^0.30.3",


### PR DESCRIPTION
## Summary
- integrate ReactQuill text editor for article creation
- add settings page to toggle whether authors can publish from app
- create backend Setting entity and endpoints with publishing check

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config' is not defined)
- `cd backend && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6897b369f3408326a5175b0b0bf18987