### PR TITLE
Add admin development notes page and routing

### DIFF
--- a/frontend/src/admin/AdminLayout.jsx
+++ b/frontend/src/admin/AdminLayout.jsx
@@ -4,6 +4,7 @@ import { Box, Drawer, List, ListItem, ListItemButton, ListItemIcon, ListItemText
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ArticleIcon from '@mui/icons-material/Article';
 import PeopleIcon from '@mui/icons-material/People';
+import NotesIcon from '@mui/icons-material/Notes';
 import SettingsIcon from '@mui/icons-material/Settings';
 
 const drawerWidth = 260;
@@ -13,6 +14,7 @@ function AdminLayout() {
     { text: 'Anasayfa', icon: <DashboardIcon />, path: '/girne' },
     { text: 'Makale Yönetimi', icon: <ArticleIcon />, path: '/girne/makaleler' },
     { text: 'Yazar Yönetimi', icon: <PeopleIcon />, path: '/girne/yazarlar' },
+    { text: 'Geliştirme Notları', icon: <NotesIcon />, path: '/girne/notlar' },
     { text: 'Ayarlar', icon: <SettingsIcon />, path: '/girne/ayarlar' },
   ];
 

--- a/frontend/src/admin/pages/DevelopmentNotes.jsx
+++ b/frontend/src/admin/pages/DevelopmentNotes.jsx
@@ -1,0 +1,98 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  TextField,
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import axios from 'axios';
+
+function DevelopmentNotes() {
+  const [notes, setNotes] = useState([]);
+  const [newNote, setNewNote] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const fetchNotes = async () => {
+    setLoading(true);
+    setError('');
+    const token = localStorage.getItem('token');
+    try {
+      const res = await axios.get('/api/dev-notes', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setNotes(res.data);
+    } catch (err) {
+      setError('Notlar yüklenirken bir hata oluştu.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchNotes();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    try {
+      const res = await axios.post(
+        '/api/dev-notes',
+        { content: newNote },
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      setNotes((prev) => [...prev, res.data]);
+      setNewNote('');
+    } catch (err) {
+      setError('Not eklenirken bir hata oluştu.');
+    }
+  };
+
+  if (loading) {
+    return <CircularProgress sx={{ display: 'block', margin: 'auto', mt: 4 }} />;
+  }
+
+  return (
+    <Box>
+      <Paper sx={{ p: 3 }}>
+        <Typography variant="h5" gutterBottom>
+          Geliştirme Notları
+        </Typography>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        <List>
+          {notes.map((note) => (
+            <ListItem key={note.id} divider>
+              <ListItemText primary={note.content || note.text || note.note} />
+            </ListItem>
+          ))}
+        </List>
+        <Box component="form" onSubmit={handleSubmit} sx={{ mt: 2 }}>
+          <TextField
+            label="Yeni Not"
+            value={newNote}
+            onChange={(e) => setNewNote(e.target.value)}
+            fullWidth
+            multiline
+          />
+          <Button type="submit" variant="contained" sx={{ mt: 1 }}>
+            Ekle
+          </Button>
+        </Box>
+      </Paper>
+    </Box>
+  );
+}
+
+export default DevelopmentNotes;
+

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -19,6 +19,7 @@ import AdminDashboard from './admin/pages/AdminDashboard.jsx';
 import LoginPage from './admin/pages/LoginPage.jsx';
 import MakaleYonetimi from './admin/pages/MakaleYonetimi.jsx';
 import YazarYonetimi from './admin/pages/YazarYonetimi.jsx';
+import DevelopmentNotes from './admin/pages/DevelopmentNotes.jsx';
 import Ayarlar from './admin/pages/Ayarlar.jsx';
 
 const router = createBrowserRouter([
@@ -40,6 +41,7 @@ const router = createBrowserRouter([
       { index: true, element: <AdminDashboard /> },
       { path: "makaleler", element: <MakaleYonetimi /> },
       { path: "yazarlar", element: <YazarYonetimi /> },
+      { path: "notlar", element: <DevelopmentNotes /> },
       { path: "ayarlar", element: <Ayarlar /> },
     ]
   },


### PR DESCRIPTION
## Summary
- add `DevelopmentNotes` admin page to list and create dev notes via API
- wire development notes into admin menu and routing

## Testing
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6897b8298acc83269fd237554dfbc765