### PR TITLE
Add development note entity and API routes

### DIFF
--- a/backend/data-source.ts
+++ b/backend/data-source.ts
@@ -3,6 +3,7 @@ import { DataSource } from "typeorm";
 import { User } from "./entities/user.js";
 import { Makale } from "./entities/Makale.js";
 import { Setting } from "./entities/Setting.js";
+import { DevelopmentNote } from "./entities/DevelopmentNote.js";
 
 
 
@@ -16,5 +17,5 @@ export const AppDataSource = new DataSource({
     database: process.env.DB_DATABASE,
     synchronize: true,
     logging: false,
-    entities: [User, Makale, Setting],
+    entities: [User, Makale, Setting, DevelopmentNote],
 });

--- a/backend/entities/DevelopmentNote.ts
+++ b/backend/entities/DevelopmentNote.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from "typeorm";
+
+@Entity()
+export class DevelopmentNote {
+    @PrimaryGeneratedColumn()
+    id!: number;
+
+    @Column()
+    title!: string;
+
+    @Column()
+    content!: string;
+
+    @CreateDateColumn()
+    createdAt!: Date;
+
+    @UpdateDateColumn()
+    updatedAt!: Date;
+}
+

--- a/backend/entities/Setting.ts
+++ b/backend/entities/Setting.ts
@@ -3,8 +3,8 @@ import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 @Entity()
 export class Setting {
     @PrimaryGeneratedColumn()
-    id: number;
+    id!: number;
 
     @Column({ default: true })
-    allowAppPublishing: boolean;
+    allowAppPublishing!: boolean;
 }

--- a/backend/router/devNoteRouter.ts
+++ b/backend/router/devNoteRouter.ts
@@ -1,0 +1,38 @@
+import { Router } from 'express';
+import { AppDataSource } from '../data-source.js';
+import { DevelopmentNote } from '../entities/DevelopmentNote.js';
+import { protect, authorize } from '../middleware/authMiddleware.js';
+import { UserRole } from '../entities/user.js';
+
+export const router = Router();
+const devNoteRepo = AppDataSource.getRepository(DevelopmentNote);
+
+// GET /api/dev-notes - List all development notes
+router.get('/', async (req, res) => {
+        try {
+                const notes = await devNoteRepo.find();
+                res.json(notes);
+        } catch (error) {
+                res.status(500).json({ message: 'Geli\u015ftirme notlar\u0131 getirilirken bir hata olu\u015ftu.', error });
+        }
+});
+
+// POST /api/dev-notes - Create a new development note
+router.post('/', protect, authorize(UserRole.ADMIN, UserRole.SUPERADMIN), async (req, res) => {
+        const { title, content } = req.body;
+        if (!title || !content) {
+                return res.status(400).json({ message: 'Ba\u015fl\u0131k ve i\u00e7erik alanlar\u0131 zorunludur.' });
+        }
+        try {
+                const note = new DevelopmentNote();
+                note.title = title;
+                note.content = content;
+                await devNoteRepo.save(note);
+                res.status(201).json(note);
+        } catch (error) {
+                res.status(500).json({ message: 'Geli\u015ftirme notu olu\u015fturulurken bir hata olu\u015ftu.', error });
+        }
+});
+
+export default router;
+

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -5,6 +5,7 @@ import { router as authRouter } from './router/authRoute.js';
 import { router as yazarRouter } from './router/yazarRouter.js';
 import { router as makaleRouter } from './router/makaleRouter.js';
 import { router as settingsRouter } from './router/settingsRouter.js';
+import { router as devNoteRouter } from './router/devNoteRouter.js';
 
 AppDataSource.initialize()
     .then(() => {
@@ -16,6 +17,7 @@ AppDataSource.initialize()
         app.use('/api/auth', authRouter);
         app.use('/api/yazarlar', yazarRouter);
         app.use('/api/makaleler', makaleRouter);
+        app.use('/api/dev-notes', devNoteRouter);
         app.use('/api/settings', settingsRouter);
 
         const port = process.env.PORT || 5000;


### PR DESCRIPTION
## Summary
- add DevelopmentNote TypeORM entity
- expose /api/dev-notes for listing and creating development notes
- mount dev note router in server and register entity in data source
- fix Setting entity definitions for strict TypeScript build

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897b8326e6c8326a0313a5d52a07a2d