### PR TITLE
Add development notes admin page

### DIFF
--- a/frontend/src/admin/AdminLayout.jsx
+++ b/frontend/src/admin/AdminLayout.jsx
@@ -5,6 +5,7 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import ArticleIcon from '@mui/icons-material/Article';
 import PeopleIcon from '@mui/icons-material/People';
 import SettingsIcon from '@mui/icons-material/Settings';
+import NoteIcon from '@mui/icons-material/Note';
 
 const drawerWidth = 260;
 
@@ -14,6 +15,7 @@ function AdminLayout() {
     { text: 'Makale Yönetimi', icon: <ArticleIcon />, path: '/girne/makaleler' },
     { text: 'Yazar Yönetimi', icon: <PeopleIcon />, path: '/girne/yazarlar' },
     { text: 'Ayarlar', icon: <SettingsIcon />, path: '/girne/ayarlar' },
+    { text: 'Geliştirme Notları', icon: <NoteIcon />, path: '/girne/notlar' },
   ];
 
   return (

--- a/frontend/src/admin/pages/GelistirmeNotlari.jsx
+++ b/frontend/src/admin/pages/GelistirmeNotlari.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { Paper, Typography, TextField, Button, List, ListItem, ListItemText } from '@mui/material';
+import axios from 'axios';
+
+const GelistirmeNotlari = () => {
+        const [notes, setNotes] = useState([]);
+        const [title, setTitle] = useState('');
+        const [content, setContent] = useState('');
+
+        const fetchNotes = async () => {
+                try {
+                        const res = await axios.get('/api/dev-notes');
+                        setNotes(res.data);
+                } catch (err) {
+                        console.error(err);
+                }
+        };
+
+        useEffect(() => {
+                fetchNotes();
+        }, []);
+
+        const handleSubmit = async (e) => {
+                e.preventDefault();
+                try {
+                        await axios.post('/api/dev-notes', { title, content });
+                        setTitle('');
+                        setContent('');
+                        fetchNotes();
+                } catch (err) {
+                        console.error(err);
+                }
+        };
+
+        return (
+                <Paper sx={{ p: 3 }}>
+                        <Typography variant="h5" gutterBottom>
+                                Geliştirme Notları
+                        </Typography>
+                        <form onSubmit={handleSubmit}>
+                                <TextField
+                                        label="Başlık"
+                                        fullWidth
+                                        value={title}
+                                        onChange={(e) => setTitle(e.target.value)}
+                                        margin="normal"
+                                />
+                                <TextField
+                                        label="İçerik"
+                                        fullWidth
+                                        multiline
+                                        rows={4}
+                                        value={content}
+                                        onChange={(e) => setContent(e.target.value)}
+                                        margin="normal"
+                                />
+                                <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+                                        Not Ekle
+                                </Button>
+                        </form>
+                        <List sx={{ mt: 4 }}>
+                                {notes.map((note, index) => (
+                                        <ListItem key={index} alignItems="flex-start">
+                                                <ListItemText primary={note.title} secondary={note.content} />
+                                        </ListItem>
+                                ))}
+                        </List>
+                </Paper>
+        );
+};
+
+export default GelistirmeNotlari;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -20,6 +20,7 @@ import LoginPage from './admin/pages/LoginPage.jsx';
 import MakaleYonetimi from './admin/pages/MakaleYonetimi.jsx';
 import YazarYonetimi from './admin/pages/YazarYonetimi.jsx';
 import Ayarlar from './admin/pages/Ayarlar.jsx';
+import GelistirmeNotlari from './admin/pages/GelistirmeNotlari.jsx';
 
 const router = createBrowserRouter([
   {
@@ -41,6 +42,7 @@ const router = createBrowserRouter([
       { path: "makaleler", element: <MakaleYonetimi /> },
       { path: "yazarlar", element: <YazarYonetimi /> },
       { path: "ayarlar", element: <Ayarlar /> },
+      { path: "notlar", element: <GelistirmeNotlari /> },
     ]
   },
   {


### PR DESCRIPTION
## Summary
- add Geliştirme Notları menu link in admin layout
- create Geliştirme Notları page for fetching and adding notes
- wire Geliştirme Notları into admin router

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports")*

------
https://chatgpt.com/codex/tasks/task_e_6897b8332ebc8326b2e5938297c51335