### PR TITLE
Add development note entity and admin routes

### DIFF
--- a/backend/data-source.ts
+++ b/backend/data-source.ts
@@ -3,6 +3,7 @@ import { DataSource } from "typeorm";
 import { User } from "./entities/user.js";
 import { Makale } from "./entities/Makale.js";
 import { Setting } from "./entities/Setting.js";
+import { DevelopmentNote } from "./entities/DevelopmentNote.js";
 
 
 
@@ -16,5 +17,5 @@ export const AppDataSource = new DataSource({
     database: process.env.DB_DATABASE,
     synchronize: true,
     logging: false,
-    entities: [User, Makale, Setting],
+    entities: [User, Makale, Setting, DevelopmentNote],
 });

--- a/backend/entities/DevelopmentNote.ts
+++ b/backend/entities/DevelopmentNote.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity()
+export class DevelopmentNote {
+    @PrimaryGeneratedColumn()
+    id!: number;
+
+    @Column('text')
+    content!: string;
+
+    @CreateDateColumn()
+    createdAt!: Date;
+}

--- a/backend/entities/Setting.ts
+++ b/backend/entities/Setting.ts
@@ -3,8 +3,8 @@ import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 @Entity()
 export class Setting {
     @PrimaryGeneratedColumn()
-    id: number;
+    id!: number;
 
     @Column({ default: true })
-    allowAppPublishing: boolean;
+    allowAppPublishing!: boolean;
 }

--- a/backend/router/devNoteRouter.ts
+++ b/backend/router/devNoteRouter.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express';
+import { AppDataSource } from '../data-source.js';
+import { DevelopmentNote } from '../entities/DevelopmentNote.js';
+import { protect, authorize } from '../middleware/authMiddleware.js';
+import { UserRole } from '../entities/user.js';
+
+export const router = Router();
+const devNoteRepo = AppDataSource.getRepository(DevelopmentNote);
+
+router.get('/', protect, authorize(UserRole.ADMIN, UserRole.SUPERADMIN), async (req, res) => {
+        try {
+                const notes = await devNoteRepo.find();
+                res.json(notes);
+        } catch (error) {
+                res.status(500).json({ message: 'Development notes fetch error.', error });
+        }
+});
+
+router.post('/', protect, authorize(UserRole.ADMIN, UserRole.SUPERADMIN), async (req, res) => {
+        const { content } = req.body;
+        if (!content) {
+                return res.status(400).json({ message: 'İçerik alanı zorunludur.' });
+        }
+        try {
+                const note = devNoteRepo.create({ content });
+                await devNoteRepo.save(note);
+                res.status(201).json(note);
+        } catch (error) {
+                res.status(500).json({ message: 'Development note oluşturulurken bir hata oluştu.', error });
+        }
+});
+
+export default router;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -5,6 +5,7 @@ import { router as authRouter } from './router/authRoute.js';
 import { router as yazarRouter } from './router/yazarRouter.js';
 import { router as makaleRouter } from './router/makaleRouter.js';
 import { router as settingsRouter } from './router/settingsRouter.js';
+import { router as devNoteRouter } from './router/devNoteRouter.js';
 
 AppDataSource.initialize()
     .then(() => {
@@ -17,6 +18,7 @@ AppDataSource.initialize()
         app.use('/api/yazarlar', yazarRouter);
         app.use('/api/makaleler', makaleRouter);
         app.use('/api/settings', settingsRouter);
+        app.use('/api/dev-notes', devNoteRouter);
 
         const port = process.env.PORT || 5000;
         app.listen(port, () => {


### PR DESCRIPTION
## Summary
- add DevelopmentNote entity to record backend development notes
- expose admin-only GET/POST /api/dev-notes endpoints
- register dev-notes router and include entity in data source
- ensure Setting entity fields satisfy strict initialization

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897b84821148326ae2036e3d9cc75b5