### PR TITLE
Add Girne admin login and protected panel

### DIFF
--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,22 @@
+import axios from "axios";
+
+const http = axios.create({
+  baseURL: import.meta.env.PROD ? import.meta.env.VITE_API_URL : "",
+  withCredentials: false,
+});
+
+export function setToken(token: string | null) {
+  if (token) localStorage.setItem("token", token);
+  else localStorage.removeItem("token");
+}
+export function getToken(): string | null {
+  return localStorage.getItem("token");
+}
+
+http.interceptors.request.use((config) => {
+  const t = getToken();
+  if (t) config.headers.Authorization = `Bearer ${t}`;
+  return config;
+});
+
+export default http;

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+export default function ProtectedRoute({ requireAdmin = true }: { requireAdmin?: boolean }) {
+  const { user, loading } = useAuth();
+  if (loading) return null; // veya küçük bir spinner
+  if (!user) return <Navigate to="/girne" replace />;
+  if (requireAdmin && user.role !== "admin") return <Navigate to="/girne" replace />;
+  return <Outlet />;
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import http, { setToken, getToken } from "../api/http";
+
+type User = { id: number; name: string; role: string } | null;
+type Ctx = {
+  user: User;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+};
+const AuthCtx = createContext<Ctx>(null as any);
+
+export const AuthProvider: React.FC<{children: React.ReactNode}> = ({ children }) => {
+  const [user, setUser] = useState<User>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (!getToken()) return;
+        const r = await http.get("/api/auth/me");
+        setUser(r.data?.user ?? null);
+      } catch {}
+      finally { setLoading(false); }
+    })();
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    const r = await http.post("/api/auth/login", { email, password });
+    const token = r.data?.token as string | undefined;
+    if (!token) throw new Error("Token gelmedi");
+    setToken(token);
+    setUser(r.data?.user ?? null);
+  };
+
+  const logout = () => { setToken(null); setUser(null); };
+
+  return <AuthCtx.Provider value={{ user, loading, login, logout }}>{children}</AuthCtx.Provider>;
+};
+
+export const useAuth = () => useContext(AuthCtx);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme.js';
@@ -8,52 +8,39 @@ import './index.css';
 
 import App from './App.jsx';
 import HomePage from './pages/HomePage.jsx';
-import HakkimizdaPage from './pages/HakkimizdaPage.jsx';
 import TarihcePage from './pages/TarihcePage.jsx';
 import YonetimKuruluPage from './pages/YonetimKuruluPage.jsx';
 import HaberDetayPage from './pages/HaberDetayPage.jsx';
 import PlaceholderPage from './pages/PlaceholderPage.jsx';
 
-import AdminLayout from './admin/AdminLayout.jsx';
-import AdminDashboard from './admin/pages/AdminDashboard.jsx';
-import LoginPage from './admin/pages/LoginPage.jsx';
-import MakaleYonetimi from './admin/pages/MakaleYonetimi.jsx';
-import YazarYonetimi from './admin/pages/YazarYonetimi.jsx';
-import Ayarlar from './admin/pages/Ayarlar.jsx';
-
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <App />,
-    children: [
-      { index: true, element: <HomePage /> },
-      { path: "kurumsal/tarihce", element: <TarihcePage /> },
-      { path: "kurumsal/yonetim-kurulu", element: <YonetimKuruluPage /> },
-      { path: "haber/:id", element: <HaberDetayPage /> },
-      { path: "*", element: <PlaceholderPage title="Sayfa Hazırlanıyor" /> },
-    ]
-  },
-  {
-    path: "/girne",
-    element: <AdminLayout />,
-    children: [
-      { index: true, element: <AdminDashboard /> },
-      { path: "makaleler", element: <MakaleYonetimi /> },
-      { path: "yazarlar", element: <YazarYonetimi /> },
-      { path: "ayarlar", element: <Ayarlar /> },
-    ]
-  },
-  {
-    path: "/login",
-    element: <LoginPage />
-  }
-]);
+import GirneLogin from './pages/GirneLogin';
+import GirnePanel from './pages/GirnePanel';
+import ProtectedRoute from './components/ProtectedRoute';
+import { AuthProvider } from './context/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <RouterProvider router={router} />
+      <AuthProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<App />}>
+              <Route index element={<HomePage />} />
+              <Route path="kurumsal/tarihce" element={<TarihcePage />} />
+              <Route path="kurumsal/yonetim-kurulu" element={<YonetimKuruluPage />} />
+              <Route path="haber/:id" element={<HaberDetayPage />} />
+              <Route path="*" element={<PlaceholderPage title="Sayfa Hazırlanıyor" />} />
+            </Route>
+
+            <Route path="/girne" element={<GirneLogin />} />
+
+            <Route element={<ProtectedRoute requireAdmin />}> 
+              <Route path="/girne/panel" element={<GirnePanel />} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </AuthProvider>
     </ThemeProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/pages/GirneLogin.tsx
+++ b/frontend/src/pages/GirneLogin.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+import { Box, Button, Container, Paper, Stack, TextField, Typography, Alert } from "@mui/material";
+import { useNavigate, Navigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+export default function GirneLogin() {
+  const { user, login } = useAuth();
+  const nav = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [err, setErr] = useState<string|null>(null);
+
+  if (user) return <Navigate to="/girne/panel" replace />;
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErr(null);
+    try { await login(email, password); nav("/girne/panel"); }
+    catch (e: any) { setErr(e?.response?.data?.message || e?.message || "Giriş başarısız"); }
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 8 }}>
+      <Paper sx={{ p: 3 }}>
+        <Typography variant="h5" fontWeight={700} mb={2}>Girne — Yönetim Girişi</Typography>
+        <Box component="form" onSubmit={submit}>
+          <Stack spacing={2}>
+            {err && <Alert severity="error">{err}</Alert>}
+            <TextField label="E-posta" value={email} onChange={e=>setEmail(e.target.value)} required />
+            <TextField label="Şifre" type="password" value={password} onChange={e=>setPassword(e.target.value)} required />
+            <Button type="submit" variant="contained">Giriş yap</Button>
+          </Stack>
+        </Box>
+      </Paper>
+    </Container>
+  );
+}

--- a/frontend/src/pages/GirnePanel.tsx
+++ b/frontend/src/pages/GirnePanel.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import { Box, Button, Container, Paper, Stack, TextField, Typography, Alert } from "@mui/material";
+import http from "../api/http";
+import { useAuth } from "../context/AuthContext";
+
+export default function GirnePanel() {
+  const { logout } = useAuth();
+  const [baslik, setBaslik] = useState("");
+  const [icerik, setIcerik] = useState("");
+  const [kategori, setKategori] = useState("");
+  const [kapakResmi, setKapakResmi] = useState("");
+  const [ok, setOk] = useState<string|null>(null);
+  const [err, setErr] = useState<string|null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault(); setOk(null); setErr(null);
+    try {
+      const body = { baslik, icerik, kategori, kapakResmi: kapakResmi || undefined, tarih: new Date().toISOString() };
+      const r = await http.post("/api/makaleler", body);
+      setOk("Makale eklendi (ID: " + r.data?.data?.id + ")");
+      setBaslik(""); setIcerik(""); setKategori(""); setKapakResmi("");
+    } catch (e: any) {
+      const s = e?.response?.status;
+      if (s === 401) setErr("Oturum gerekli. Lütfen /girne’den giriş yapın.");
+      else if (s === 403) setErr("Admin izni gerekli.");
+      else setErr(e?.response?.data?.message || e?.message || "Kayıt başarısız");
+    }
+  };
+
+  return (
+    <Container maxWidth="md" sx={{ py: 6 }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
+        <Typography variant="h5" fontWeight={700}>Girne Paneli — Makale Ekle</Typography>
+        <Button onClick={logout} color="inherit">Çıkış</Button>
+      </Stack>
+      <Paper sx={{ p: 3 }}>
+        <Box component="form" onSubmit={submit}>
+          <Stack spacing={2}>
+            {ok && <Alert severity="success">{ok}</Alert>}
+            {err && <Alert severity="error">{err}</Alert>}
+            <TextField label="Başlık" value={baslik} onChange={e=>setBaslik(e.target.value)} required />
+            <TextField label="Kategori" value={kategori} onChange={e=>setKategori(e.target.value)} placeholder="Basında KKTC" />
+            <TextField label="Kapak Görseli (URL)" value={kapakResmi} onChange={e=>setKapakResmi(e.target.value)} />
+            <TextField label="İçerik" value={icerik} onChange={e=>setIcerik(e.target.value)} multiline minRows={6} required />
+            <Button type="submit" variant="contained">Kaydet</Button>
+          </Stack>
+        </Box>
+      </Paper>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- add axios wrapper with token storage and Authorization header
- implement AuthContext and ProtectedRoute for admin auth
- add Girne login page and protected panel
- wire up routes with AuthProvider and hidden paths

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*


------
https://chatgpt.com/codex/tasks/task_e_6897d466976c8326be2956f551170a70