### PR TITLE
Restore settings endpoint and normalize API responses

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
+PORT=5000
 DB_HOST=localhost
 DB_USER=root
-DB_PASSWORD=****
+DB_PASSWORD=changeme
 DB_DATABASE=kibristkd
-JWT_SECRET=supersecretkey
+JWT_SECRET=change_this_to_a_long_random_value

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
       "start": "node --env-file=.env dist/server.js",
       "dev": "nodemon --exec ts-node src/server.ts",
       "seed:user": "node --env-file=.env dist/scripts/createUser.js",
-      "seed:admin": "npm run seed:user -- --email=admin@example.com --password=123456 --name=Admin --role=admin"
+      "seed:admin": "npm run seed:user -- --email=admin@example.com --password=Admin123! --name=Admin --role=admin"
     },
   "type": "module",
   "keywords": [],

--- a/backend/router/settingsRouter.ts
+++ b/backend/router/settingsRouter.ts
@@ -1,0 +1,18 @@
+import { Router } from "express";
+
+export const router = Router();
+
+/**
+ * Frontend GlobalContent.jsx beklediği için /api/settings/content geri eklendi.
+ * Şimdilik statik payload dönüyoruz. İleride DB'den okuyacak şekilde genişletilebilir.
+ */
+router.get("/content", async (_req, res) => {
+  const payload = {
+    heroTitle: "Kıbrıs TKD",
+    heroSubtitle: "Gündemden öne çıkanlar",
+    banners: [],
+    sections: []
+  };
+  return res.json({ success: true, data: payload });
+});
+

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,15 +1,28 @@
 import express from "express";
+import cors from "cors";
 import { AppDataSource } from "./data-source.js";
 import { router as authRouter } from "./router/authRoute.js";
 import { router as makaleRouter } from "./router/makaleRouter.js";
+import { router as settingsRouter } from "./router/settingsRouter.js";
+
+console.log("Veritabanı bağlantısı denetleniyor...");
 
 AppDataSource.initialize()
   .then(() => {
+    console.log("Veritabanı bağlantısı başarıyla kuruldu!");
     const app = express();
     app.use(express.json());
 
+    app.use(
+      cors({
+        origin: "http://localhost:5173",
+        credentials: false,
+      })
+    );
+
     app.use("/api/auth", authRouter);
     app.use("/api/makaleler", makaleRouter);
+    app.use("/api/settings", settingsRouter);
 
     const port = process.env.PORT || 5000;
     app.listen(port, () => {

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -19,4 +19,10 @@ http.interceptors.request.use((config) => {
   return config;
 });
 
+export function unwrap<T = any>(resp: any, fallback: T): T {
+  if (resp?.data?.data !== undefined) return resp.data.data as T;
+  if (resp?.data !== undefined) return resp.data as T;
+  return fallback;
+}
+
 export default http;

--- a/frontend/src/components/GlobalContent.jsx
+++ b/frontend/src/components/GlobalContent.jsx
@@ -1,23 +1,27 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, Container } from '@mui/material';
-import axios from 'axios';
+import http, { unwrap } from '../api/http';
 
 const GlobalContent = () => {
   const [content, setContent] = useState('');
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     const fetchContent = async () => {
       try {
-        const res = await axios.get('/api/settings/content');
-        setContent(res.data.globalContent || '');
+        const r = await http.get('/api/settings/content');
+        const data = unwrap(r, {});
+        setContent(data.globalContent || '');
       } catch (err) {
         console.error(err);
+        setError(true);
+        setContent('');
       }
     };
     fetchContent();
   }, []);
 
-  if (!content) return null;
+  if (error || !content) return null;
 
   return (
     <Box sx={{ bgcolor: 'secondary.main', color: 'secondary.contrastText', py: 2 }}>

--- a/frontend/src/components/MainContentSlider.jsx
+++ b/frontend/src/components/MainContentSlider.jsx
@@ -7,7 +7,8 @@ import { Box, Typography } from '@mui/material';
 import HaberKarti from './HaberKarti';
 
 function MainContentSlider({ makaleler }) {
-  if (!makaleler || makaleler.length === 0) {
+  const items = Array.isArray(makaleler) ? makaleler : [];
+  if (items.length === 0) {
     return <Typography>Gösterilecek haber bulunmuyor.</Typography>;
   }
 
@@ -26,7 +27,7 @@ function MainContentSlider({ makaleler }) {
           },
         }}
       >
-        {makaleler.map((makale) => (
+        {items.map((makale) => (
           <SwiperSlide key={makale.id}>
             <HaberKarti
               id={makale.id}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -23,7 +23,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <AuthProvider>
-        <BrowserRouter>
+        <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
           <Routes>
             <Route path="/" element={<App />}>
               <Route index element={<HomePage />} />

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Container, Grid, Box, Typography } from '@mui/material';
-import axios from 'axios';
+import http, { unwrap } from '../api/http';
 
 import HeroSlider from '@/components/HeroSlider';
 import MainContentSlider from '@/components/MainContentSlider';
@@ -15,11 +15,13 @@ const HomePage = () => {
     useEffect(() => {
         const fetchMakaleler = async () => {
             try {
-                const response = await axios.get('/api/makaleler');
-                setMakaleler(response.data);
+                const r = await http.get('/api/makaleler');
+                const items = unwrap(r, []);
+                setMakaleler(Array.isArray(items) ? items : []);
             } catch (err) {
                 setError('Makaleler yüklenirken bir sorun oluştu.');
                 console.error(err);
+                setMakaleler([]);
             } finally {
                 setLoading(false);
             }


### PR DESCRIPTION
## Summary
- restore `/api/settings/content` with static payload and enable CORS
- normalize frontend HTTP responses and guard against missing arrays
- add future flags for Router and handle GlobalContent and slider safety

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports")*
- `npm run build`
- `cd backend && npm test` *(fails: Error: no test specified)*
- `npm run build`
- `npm run start` *(fails: connect ENETUNREACH 104.247.167.147:3306)*

------
https://chatgpt.com/codex/tasks/task_e_6897d79c39808326967dbe1537176e9d